### PR TITLE
remove CACHE from endpoint.py

### DIFF
--- a/pynetbox/lib/endpoint.py
+++ b/pynetbox/lib/endpoint.py
@@ -18,8 +18,6 @@ from collections import defaultdict
 from pynetbox.lib.query import Request, url_param_builder
 from pynetbox.lib.response import Record, IPRecord
 
-CACHE = defaultdict(list)
-
 
 class Endpoint(object):
     """Represent actions available on endpoints in the Netbox API.
@@ -220,15 +218,8 @@ class Endpoint(object):
         >>>
         """
 
-        cache = kwargs.pop('cache', False)
-
         if len(args) > 0:
             kwargs.update({'q': args[0]})
-
-        if cache:
-            ret = CACHE.get(self.endpoint_name)
-            if ret:
-                return ret
 
         req = Request(
             filters=kwargs,
@@ -246,7 +237,6 @@ class Endpoint(object):
             self.return_obj(i, **ret_kwargs)
             for i in req.get()
         ]
-        CACHE[self.endpoint_name].extend(ret)
         return ret
 
     def create(self, *args, **kwargs):


### PR DESCRIPTION
Using pynetbox to refresh the set of devices needed to be monitored in an own written prometheus metric exporter, I got bitten by a kind of memory leak: the daemon process was steadily increasing memory until out-of-memory.

I tracked that down to endpoint.py, as every call of .dcim.devices.filter() without changing arguments has increased the memory consumption by additional 700KiB

So CACHE is per call of filter() just eating memory and keeps gc away from cleaning Request objects. In addition the argument `cache` of function filter() is not documented and (if you know and use it) the result in case of `cache=True` is weird/wrong, as only self.endpoint_name is used as key for lookup in CACHE (it doesn't consider the query arguments)